### PR TITLE
Add test folder to gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 /.gitignore export-ignore
 /.travis.yml export-ignore
 /phpcs.xml export-ignore
+/test export-ignore


### PR DESCRIPTION
Add the test folder to `.gitattributes` with `export-ignore` flag set, so they're not pulled down as part of a project's dependencies via composer.