### PR TITLE
PHPUnit fixes + CI bumps

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,8 @@
 name: Tests
 
+permissions:
+  contents: read
+
 on: [push, pull_request]
 
 jobs:
@@ -21,10 +24,10 @@ jobs:
           git config --global core.eol lf
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.composer/cache/files
           key: dependencies-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
@@ -44,4 +47,3 @@ jobs:
 
       - name: Code Sniffer
         run: vendor/bin/phpcs
-

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": ">=7.1 <9.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7 | ^8 | ^9",
+        "phpunit/phpunit": "^7 || ^8 || ^9 || ^10",
         "squizlabs/php_codesniffer": "*"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": ">=7.1 <9.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7 || ^8 || ^9 || ^10",
+        "phpunit/phpunit": "^7 || ^8 || ^9 || ^10 || ^11",
         "squizlabs/php_codesniffer": "*"
     },
     "autoload": {

--- a/test/EnumMapTest.php
+++ b/test/EnumMapTest.php
@@ -91,7 +91,7 @@ final class EnumMapTest extends TestCase
         $map->put(Planet::MARS(), 'foo');
     }
 
-    public function invalidValues() : array
+    public static function invalidValues() : array
     {
         return [
             ['bool', null, false],
@@ -119,7 +119,7 @@ final class EnumMapTest extends TestCase
         $map->put(WeekDay::TUESDAY(), $value);
     }
 
-    public function validValues() : array
+    public static function validValues() : array
     {
         return [
             ['bool', null],

--- a/test/EnumMapTest.php
+++ b/test/EnumMapTest.php
@@ -112,6 +112,7 @@ final class EnumMapTest extends TestCase
      * @dataProvider invalidValues
      * @param mixed $value
      */
+     #[\PHPUnit\Framework\Attributes\DataProvider('invalidValues')]
     public function testPutInvalidValue(string $valueType, $value, bool $allowNull = true) : void
     {
         $this->expectException(IllegalArgumentException::class);
@@ -143,6 +144,7 @@ final class EnumMapTest extends TestCase
      * @dataProvider validValues
      * @param mixed $value
      */
+     #[\PHPUnit\Framework\Attributes\DataProvider('validValues')]
     public function testPutValidValue(string $valueType, $value, bool $allowNull = true) : void
     {
         $map = new EnumMap(WeekDay::class, $valueType, $allowNull);


### PR DESCRIPTION
No breaking change here, the change to `static function` should have been done quite a while ago but phpunit only warns since version 10.